### PR TITLE
Display the spoiler box for the first card as well

### DIFF
--- a/tests/DummyAccountUtils.js
+++ b/tests/DummyAccountUtils.js
@@ -53,6 +53,7 @@ exports.populateDummyAccount = function(numCards=50) {
                     if (i % 3 == 0) card.isPublic = false;
                     else card.isPublic = true;
                     await CardsDB.create(card);
+                    console.log(`${i}/${cards.length}: ${card.title}`);
                 }
                 resolve(loggedInUser)
             })

--- a/views/pages/browse_cards_page.ejs
+++ b/views/pages/browse_cards_page.ejs
@@ -148,7 +148,8 @@
                 )
                 .then(() => { return cardsManager.next(); })
                 .then((card) => { 
-                    renderCard(card); 
+                    // 2x so that the spoiler box can have positive dimensions
+                    renderCard(card); renderCard(card);
                     elementRefs.cardContainerHolderElement.style.display = "block";
                 })
                 .catch((err) => { console.error(err); });

--- a/views/pages/home.ejs
+++ b/views/pages/home.ejs
@@ -205,7 +205,10 @@
             function displayFullCard(cardID) {
                 cardsManager
                     .fetchCard(cardID)
-                    .then((card) => { renderCard(card); })
+                    .then((card) => { 
+                        // 2x so that the spoiler box can have positive dimensions
+                        renderCard(card); renderCard(card); 
+                    })
                     .catch((err) => { console.error(err); });
             }
 


### PR DESCRIPTION
Previously, the spoiler box for the card that starts the queue was
missing. This happened because the dimensions for the card
description area were still zero. The method set up a spoiler box of
height zero. We fixed this by calling the `renderCard` function 2x
whenever we start viewing a deck of cards. This closes #38