### PR TITLE
Stop overriding the arrow keys

### DIFF
--- a/views/pages/home.ejs
+++ b/views/pages/home.ejs
@@ -9,24 +9,6 @@
         <script type="text/javascript" src="/dist/CardTemplateUtilities.bundle.min.js"></script>
         <script type="text/javascript" src="/dist/TagsBarUtilities.bundle.min.js"></script>
         <script type="text/javascript" src="/dist/AutoComplete.bundle.min.js"></script>
-        <script type="text/javascript">
-
-            /**
-             * @description Make LEFT/RIGHT arrow keys show PREVIOUS/NEXT card.
-             */ 
-            function arrowKeysForNavigation(event) {
-                if (event.key === "ArrowLeft") {
-                    fetchPreviousCard();
-                    event.preventDefault();
-                } else if (event.key === "ArrowRight") {
-                    fetchNextCard();
-                    event.preventDefault();
-                }
-            }
-
-            window.addEventListener("keydown", arrowKeysForNavigation);
-
-        </script>
 
         <style>
             #streak_bar {
@@ -314,7 +296,6 @@
                 if (!card.title) card.title = "";
                 if (!card.urgency) card.urgency = 0;
 
-                window.addEventListener("keydown", arrowKeysForNavigation);
                 elementRefs.cardTitleElement.value = card.title;
                 
                 elementRefs.cardDescriptionElement.innerHTML = card.descriptionHTML;
@@ -367,7 +348,6 @@
             function displayRawCardDescription() {
                 elementRefs.cardDescriptionElement.innerText = state.rawDescription;
                 elementRefs.cardDescriptionElement.setAttribute("contenteditable", "true");
-                window.removeEventListener("keydown", arrowKeysForNavigation);
             }
 
             function displayNewCard() {
@@ -383,7 +363,6 @@
                 elementRefs.cardUrgencyElement.value = 10;
                 elementRefs.cardUrgencyNumberElement.innerText = "10";
                 elementRefs.cardDescriptionElement.setAttribute("contenteditable", "true");
-                window.removeEventListener("keydown", arrowKeysForNavigation);
 
                 // Reset the contents of the current_card variable
                 state.changedItems.clear();
@@ -396,12 +375,10 @@
             }
 
             function handleInputChange(element_id) {
-                window.removeEventListener("keydown", arrowKeysForNavigation);
                 state.changedItems.add(element_id);
             }
 
             function handleTagsInputChange(event) {
-                window.removeEventListener("keydown", arrowKeysForNavigation);
                 let tagBeingEntered = elementRefs.cardTagInputElement.value;
                 let keyPress = event.key;
                 // If whitespace was added, create the new tag if need be.

--- a/views/partials/search_bar_dropdown.ejs
+++ b/views/partials/search_bar_dropdown.ejs
@@ -57,17 +57,11 @@
     const CARD_SEARCH_RESULTS_ELEMENT = document.getElementById("card_search_results");
 
     /**
-     * @description Make LEFT/RIGHT arrow keys show PREVIOUS/NEXT card.
-     */ 
-    function arrowKeysForNavigation(event) {}
-
-    /**
      * @description Provide search results for queries typed in the search bar. 
      * If the user pressed the space bar, ask the server for the top 7 results. 
      * If the user pressed 'Enter', ask the server for all results.
      */
     function searchCards(event) {
-        window.removeEventListener("keydown", arrowKeysForNavigation);
         let keyPress = event.key;
         // Only query the server if the user has entered a complete word or is 
         // done typing.


### PR DESCRIPTION
Making it easier to fetch the previous/next card is not enough reason to
remove user ability to keyboard through elements. Sure, we were removing
the override when the user was typing, but that's bug-prone. Navigating
previous/next isn't that bad. We may even create non-conflicting keyboard
shortcuts down the road.

Closes #59