### PR TITLE
[Security] Remove stale MongoDB credentials

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,4 @@ services:
         value: flashcards@c13u.com
       - key: STUDY_BUDDY_MAILGUN_LOGIN # Imported from Heroku app
         value: flashcards@c13u.com
-      - key: STUDY_BUDDY_MLAB_MONGO_URI # Imported from Heroku app
-        value: mongodb+srv://c13uprod:0ZURnhGzjNhNPf9H@c13u.5uy1z.mongodb.net/c13u?retryWrites&#x3D;true&amp;w&#x3D;majority
 


### PR DESCRIPTION
Alerted by [1]. The exposed credentials have been revoked and replaced with new ones.

[1]: https://dashboard.gitguardian.com/workspace/311631/incidents/4810736?sort_date=true