### PR TITLE
[Lint] Fix violations of `no-useless-escape`

### DIFF
--- a/src/models/CardsMongoDB.ts
+++ b/src/models/CardsMongoDB.ts
@@ -198,11 +198,11 @@ export function search(
  * `arrays dynamic_programming iterative-algorithms dynamic programming iterative algorithms`
  */
 const splitTags = function(s: string): string {
-  const possibleTags = s.match(/[\w|\d]+(\_|-){1}[\w|\d]+/g);
+  const possibleTags = s.match(/[\w|\d]+(_|-){1}[\w|\d]+/g);
   if (possibleTags === null) { return s; }
 
   for (let i = 0; i < possibleTags.length; i++) {
-    s += " " + possibleTags[i].split(/[\_-]/g).join(" ");
+    s += " " + possibleTags[i].split(/[_-]/g).join(" ");
   }
   return s;
 };


### PR DESCRIPTION
Makes reading strings easier. [1]

Fixes 2 ES lint violations. 36 left till #162 is done.

[1]: https://eslint.org/docs/latest/rules/no-useless-escape