### PR TITLE
[Lint] Fix non-Mongoose violations of `no-var-requires`

### DIFF
--- a/src/routes/InAppRoutes.ts
+++ b/src/routes/InAppRoutes.ts
@@ -36,4 +36,4 @@ router.get(DOWNLOAD_USER_DATA, rateLimiter, requireLogIn, downloadUserData);
 
 router.get(DELETE_ACCOUNT, rateLimiter, requireLogIn, deleteAccount);
 
-module.exports = router;
+export = router;


### PR DESCRIPTION
Fixes 13 violations of this rule. Using `import` is preferred [1]. 12 errors left for #162.

[1]: https://typescript-eslint.io/rules/no-var-requires/